### PR TITLE
Exclude stuff from code coverage

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/CommonSettings.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/CommonSettings.cs
@@ -1,8 +1,10 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Rinkudesu.Gateways.Clients;
 
+[ExcludeFromCodeCoverage]
 public static class CommonSettings
 {
     public static readonly JsonSerializerOptions JsonOptions = new()

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Exceptions/UnexpectedResponseException.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Exceptions/UnexpectedResponseException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.Serialization;
 
 namespace Rinkudesu.Gateways.Clients.Exceptions;
 
 [Serializable]
+[ExcludeFromCodeCoverage]
 public class UnexpectedResponseException : ResponseException
 {
     public UnexpectedResponseException()

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Models/KeycloakSettings.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Models/KeycloakSettings.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Rinkudesu.Gateways.Webui.Models
 {
+    [ExcludeFromCodeCoverage]
     public class KeycloakSettings
     {
         private static KeycloakSettings? current;

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Models/MappingProfiles.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Models/MappingProfiles.cs
@@ -1,8 +1,10 @@
-﻿using AutoMapper;
+﻿using System.Diagnostics.CodeAnalysis;
+using AutoMapper;
 using Rinkudesu.Gateways.Clients.Links;
 
 namespace Rinkudesu.Gateways.Webui.Models
 {
+    [ExcludeFromCodeCoverage]
     public class MappingProfiles : Profile
     {
         public MappingProfiles()

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Utils/ControllerExtensions.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Utils/ControllerExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Rinkudesu.Gateways.Webui.Utils;
 
+[ExcludeFromCodeCoverage]
 public static class ControllerExtensions
 {
     public static IActionResult ReturnNotFound(this Controller controller, Uri redirectUri, string? errorDetails = null)

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Utils/HttpContextExtensions.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Utils/HttpContextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -10,26 +11,31 @@ namespace Rinkudesu.Gateways.Webui.Utils
 {
     public static class HttpContextExtensions
     {
+        [ExcludeFromCodeCoverage]
         public static Uri GetCurrentUrl(this HttpContext context)
         {
             return $"{context.Request.Path}{context.Request.QueryString}".ToUri();
         }
 
+        [ExcludeFromCodeCoverage]
         public static Uri GetBasePath(this HttpContext context)
         {
             return $"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}/".ToUri();
         }
 
+        [ExcludeFromCodeCoverage]
         public static string GetEncodedBasePath(this HttpContext context)
         {
             return UrlEncoder.Default.Encode(context.GetBasePath().ToString());
         }
 
+        [ExcludeFromCodeCoverage]
         public static async Task<string> GetJwt(this HttpContext context)
         {
             return await context.GetTokenAsync("access_token") ?? string.Empty;
         }
 
+        [ExcludeFromCodeCoverage]
         public static void AddErrorDetails(this HttpContext context, Uri redirectUri, string? errorDetails = null)
         {
             context.Items.Add(ErrorController.RETURN_URL_ITEM_NAME, redirectUri);


### PR DESCRIPTION
A follow-up to #85 that removes further individual classes from code-coverage.

Note that some classes have been disabled directly in Sonarqube.
