### PR TITLE
Add tag name autocompletion during tag assignment

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Tags/TagQueryDto.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Tags/TagQueryDto.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Rinkudesu.Gateways.Clients.Tags;
+
+[ExcludeFromCodeCoverage]
+[SuppressMessage("Performance", "CA1819:Properties should not return arrays")]
+public class TagQueryDto
+{
+    public string? Name { get; set; }
+
+    public static readonly TagQueryDto Empty = new();
+
+    internal string GenerateUriQueryString()
+    {
+        var queryArguments = new LinkedList<string>();
+
+        if (!string.IsNullOrWhiteSpace(Name))
+        {
+            queryArguments.AddLast($"name={Uri.EscapeDataString(Name)}");
+        }
+
+        return $"?{string.Join('&', queryArguments)}";
+    }
+}

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Tags/TagsClient.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Tags/TagsClient.cs
@@ -51,11 +51,11 @@ public class TagsClient : AccessTokenClient
         }
     }
 
-    public async Task<IEnumerable<TagDto>?> GetTags(CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<TagDto>?> GetTags(TagQueryDto tagQuery, CancellationToken cancellationToken = default)
     {
         try
         {
-            var response = await Client.GetAsync("tags".ToUri(), cancellationToken).ConfigureAwait(false);
+            var response = await Client.GetAsync($"tags{tagQuery.GenerateUriQueryString()}".ToUri(), cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 Logger.LogWarning("Received non-success status code '{StatusCode}' from tags microservice", response.StatusCode);

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/AutocompletionApi/TagsAutocompletionApiController.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/AutocompletionApi/TagsAutocompletionApiController.cs
@@ -21,8 +21,8 @@ public class TagsAutocompletionApiController : AccessTokenClientControllerBase<T
 
     public async Task<ActionResult> GetTags([FromQuery] string name, CancellationToken cancellationToken)
     {
-        //todo: this should filter by name once that becomes available in the microservice
-        var results = await Client.GetTags(cancellationToken);
+        var query = new TagQueryDto { Name = name };
+        var results = await Client.GetTags(query, cancellationToken);
         if (results is null)
             return NotFound();
 

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/TagsController.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/TagsController.cs
@@ -24,7 +24,7 @@ public class TagsController : AccessTokenClientController<TagsClient>
     [HttpGet]
     public async Task<IActionResult> Index()
     {
-        var tags = await Client.GetTags();
+        var tags = await Client.GetTags(TagQueryDto.Empty);
         if (tags is null)
             return this.ReturnNotFound("/".ToUri());
         return View(_mapper.Map<List<TagIndexViewModel>>(tags));

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/LinkTags/_CreateAssignment.cshtml
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/LinkTags/_CreateAssignment.cshtml
@@ -3,8 +3,8 @@
 <div class="mt-2">
     <form asp-action="Assign" id="assignTag">
         <input type="hidden" asp-for="LinkId"/>
-        <div class="col-6">
-            <div class="input-group" id="tag-assignment">
+        <div class="d-flex flex-column">
+            <div class="input-group flex-fill" id="tag-assignment">
                 <select class="tags-autocompletion tag-name-entry-assign" asp-for="TagId"></select>
                 <button type="submit" class="tag-display tag-assign-btn"><i class="fa-regular fa-plus"></i></button>
             </div>

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/LinkTags/_CreateAssignment.cshtml
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/LinkTags/_CreateAssignment.cshtml
@@ -3,8 +3,11 @@
 <div class="mt-2">
     <form asp-action="Assign" id="assignTag">
         <input type="hidden" asp-for="LinkId"/>
-        @*todo: this should support autocompletion*@
-        <input asp-for="TagId" class="tag-name-entry-assign"/>
-        <button type="submit" class="tag-display tag-assign-btn"><i class="fa-regular fa-plus"></i></button>
+        <div class="col-6">
+            <div class="input-group" id="tag-assignment">
+                <select class="tags-autocompletion tag-name-entry-assign" asp-for="TagId"></select>
+                <button type="submit" class="tag-display tag-assign-btn"><i class="fa-regular fa-plus"></i></button>
+            </div>
+        </div>
     </form>
 </div>

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/linkTagAssignment.js
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/linkTagAssignment.js
@@ -23,6 +23,17 @@ function onTagsLoad(responseEvent) {
 
         deleteButton.addEventListener('click', _ => onTagDelete(deleteButton));
     }
+
+    initialiseTomselect();
+
+    // make sure tomselect inputs have proper class applied
+    for (const tagNameInput of document.getElementById('tag-assignment').children) {
+        for (const tsInputDiv of tagNameInput.getElementsByClassName('ts-control')) {
+            if (!tsInputDiv.classList.contains('tag-name-entry-assign')) {
+                tsInputDiv.classList.add('tag-name-entry-assign');
+            }
+        }
+    }
 }
 
 function onTagDelete(button) {

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/site.js
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/site.js
@@ -27,7 +27,9 @@ function disableWithChildren(node, status = false) {
     }
 }
 
-window.addEventListener('load', _ => {
+window.addEventListener('load', _ => initialiseTomselect())
+
+function initialiseTomselect() {
     new TomSelect('.tags-autocompletion', {
         valueField: 'id',
         labelField: 'data',
@@ -43,4 +45,4 @@ window.addEventListener('load', _ => {
             });
         }
     });
-})
+}


### PR DESCRIPTION
Now, when assigning tags from the link details view, tag is being autocompleted when name is provided.

![image](https://user-images.githubusercontent.com/56399446/216635447-bd969516-787b-49f3-bf75-d1b71fc039c1.png)

The Tomselect styling is a bit awkward there, but oh well...

This is a part of #70.