### PR TITLE
Add session ticket storage in redis

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Models/RedisSettings.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Models/RedisSettings.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+
+namespace Rinkudesu.Gateways.Webui.Models;
+
+[ExcludeFromCodeCoverage]
+public class RedisSettings
+{
+    private static RedisSettings? current;
+
+    public static RedisSettings Current
+    {
+        get => current ?? throw new InvalidOperationException("Redis settings have not been initialised");
+        set
+        {
+            if (current is not null)
+                throw new InvalidOperationException("Redis settings have already been initialised");
+
+            current = value;
+        }
+    }
+
+    public string Address { get; }
+
+    public RedisSettings()
+    {
+        Address = Environment.GetEnvironmentVariable("RINKUDESU_REDIS_ADDRESS") ?? throw new InvalidOperationException("RINKUDESU_REDIS_ADDRESS env variable must be set");
+    }
+
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate")] // this is most certainly not appropriate
+    public RedisCacheOptions GetRedisOptions() => new RedisCacheOptions { Configuration = Address };
+}

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Properties/launchSettings.json
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Properties/launchSettings.json
@@ -12,7 +12,8 @@
         "RINKUDESU_TAGS": "http://localhost:5010/api/v0/",
         "RINKU_KAFKA_ADDRESS": "localhost:9092",
         "RINKU_KAFKA_CLIENT_ID": "rinkudesu-webui",
-        "RINKU_KAFKA_CONSUMER_GROUP_ID": "rinkudesu-webui"
+        "RINKU_KAFKA_CONSUMER_GROUP_ID": "rinkudesu-webui",
+        "RINKUDESU_REDIS_ADDRESS": "127.0.0.1:6379"
       }
     }
   }

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui.csproj
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui.csproj
@@ -21,6 +21,7 @@
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.5" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.5" />
       <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.5" />
       <PackageReference Include="Serilog" Version="2.12.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Utils/RedisCacheTicketStore.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Utils/RedisCacheTicketStore.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+
+namespace Rinkudesu.Gateways.Webui.Utils;
+
+[ExcludeFromCodeCoverage]
+public class RedisCacheTicketStore : ITicketStore
+{
+    private const string PREFIX = "SessionTicket-";
+
+    private readonly IDistributedCache _cache;
+
+    public RedisCacheTicketStore(IDistributedCache cache)
+    {
+        _cache = cache;
+    }
+
+    public RedisCacheTicketStore(RedisCacheOptions options)
+    {
+        _cache = new RedisCache(options);
+    }
+
+    public async Task<string> StoreAsync(AuthenticationTicket ticket)
+    {
+        var random = RandomNumberGenerator.GetBytes(512);
+        var key = PREFIX + Convert.ToBase64String(random);
+        await SetTicket(key, ticket);
+        return key;
+    }
+
+    public async Task RenewAsync(string key, AuthenticationTicket ticket)
+    {
+        await SetTicket(key, ticket);
+    }
+
+    public async Task<AuthenticationTicket?> RetrieveAsync(string key)
+    {
+        var bytes = await _cache.GetAsync(key);
+        if (bytes is null)
+            return null;
+        return TicketSerializer.Default.Deserialize(bytes);
+    }
+
+    public async Task RemoveAsync(string key)
+    {
+        await _cache.RemoveAsync(key);
+    }
+
+    private async Task SetTicket(string id, AuthenticationTicket ticket)
+    {
+        var cacheOptions = new DistributedCacheEntryOptions();
+        var ticketBytes = TicketSerializer.Default.Serialize(ticket);
+        if (ticket.Properties.ExpiresUtc is {} expiration)
+            cacheOptions.AbsoluteExpiration = expiration;
+        await _cache.SetAsync(id, ticketBytes, cacheOptions);
+    }
+}


### PR DESCRIPTION
This PR introduces Redis in order to store user session tickets.
It's necessary as storing entire tickets in cookies results in so much data (for whatever reason) that servers stop accepting the requests due to header size.
Now, instead of an entire state, only session id is being sent, resuling in much more sane size.

The downside is, of course, that this introduces yet another moving part, this being Redis, which is not even used or necessary apart from this single case.
However, now that it's here, maybe it will be useful in other cases when cache could prove benefitial.

I've also disabled getting claims from user info endpoint in order to initially reduce the cookie size, but this apparently does nothing anyway, so I'm just gonna leave that disabled.

Closes #163
