### PR TITLE
Send an email explaining that the account already exists when duplicate email provided

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.Designer.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.Designer.cs
@@ -62,5 +62,11 @@ namespace Rinkudesu.Gateways.Webui.Resources.Controllers {
                 return ResourceManager.GetString("click", resourceCulture);
             }
         }
+        
+        internal static string emailUsed {
+            get {
+                return ResourceManager.GetString("emailUsed", resourceCulture);
+            }
+        }
     }
 }

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.pl.Designer.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.pl.Designer.cs
@@ -62,5 +62,11 @@ namespace Rinkudesu.Gateways.Webui.Resources.Controllers {
                 return ResourceManager.GetString("click", resourceCulture);
             }
         }
+        
+        internal static string emailUsed {
+            get {
+                return ResourceManager.GetString("emailUsed", resourceCulture);
+            }
+        }
     }
 }

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.pl.resx
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.pl.resx
@@ -30,4 +30,8 @@
         <value>Potwierdź email</value>
         <comment>click</comment>
     </data>
+    <data name="emailUsed" xml:space="preserve">
+        <value>Otrzymaliśmy prośbę o założenie konta w Rinkudesu, ale wygląda na to, że Twój adres email jest już używany. Jeśli to Ty, ale o tym zapomniałeś, po prostu użyj funkcjonalności "nie pamiętam hasła". Jeśli wydaje Ci się, że to konto nie zostało stworzone przez Ciebie, natychmiast się z nami skontaktuj.</value>
+        <comment>emailUsed</comment>
+    </data>
 </root>

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.resx
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Resources/Controllers/AccountCreationController.resx
@@ -30,4 +30,8 @@
         <value>Confirm email</value>
         <comment>click</comment>
     </data>
+    <data name="emailUsed" xml:space="preserve">
+        <value>You've requested account creation at Rinkudesu, but it appears your email is already used by someone. If that's you but you've forgotten about it, just use the "forgot password" feature. If you believe this account was not created by you, contact us immediately.</value>
+        <comment>emailUsed</comment>
+    </data>
 </root>


### PR DESCRIPTION
Message displayed on the front-end will still say the same thing, though, to avoid user enumeration.

Closes #186.