### PR TITLE
Add a server-side url title fetching

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/AutocompletionApi/LinkTitleAutocompletion.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/AutocompletionApi/LinkTitleAutocompletion.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Rinkudesu.Gateways.Webui.Controllers.AutocompletionApi;
+
+[ApiController]
+[Route("api/autocompletion/[controller]")]
+[Authorize]
+[ExcludeFromCodeCoverage]
+public partial class LinkTitleAutocompletion : ControllerBase
+{
+    private readonly HttpClient _client;
+
+    public LinkTitleAutocompletion(HttpClient client)
+    {
+        _client = client;
+    }
+
+    // This is here because CORS exists and there were issues getting this title directly from the user's browser.
+    // This is not perfect and should probably be expunged from here, but I don't really see a better way of doing this ATM.
+    // todo: this doesn't fit here and should be solved in a better way
+    [HttpGet]
+    public async Task<ActionResult> GetTitleFromUrl([FromQuery] Uri url, CancellationToken cancellationToken)
+    {
+        // invoke a hard timeout limit for the entire request so as to avoid potential DOS attempts
+        using var timeoutToken = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(timeoutToken.Token, cancellationToken);
+        using var response = await _client.GetAsync(url, linkedToken.Token);
+
+        if (response.Content.Headers.ContentType!.MediaType != "text/html")
+            return NotFound();
+        var html = await response.Content.ReadAsStringAsync(linkedToken.Token);
+        var title = TitleRegex().Match(html); //thanks: https://stackoverflow.com/a/329324
+        var match = title.Groups["Title"].Value;
+        if (string.IsNullOrWhiteSpace(match))
+            return NotFound();
+        return Ok(match);
+    }
+
+    [GeneratedRegex("\\<title\\b[^>]*\\>\\s*(?<Title>[\\s\\S]*?)\\</title\\>")]
+    private static partial Regex TitleRegex();
+}

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/Links/Create.cshtml
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/Links/Create.cshtml
@@ -20,3 +20,8 @@
 </form>
 
 <a asp-action="Index" class="btn btn-dark">@Localizer["cancel"]</a>
+
+@section Scripts
+{
+    <script src="~/js/linkTitleAutoLoader.js" asp-append-version="true"></script>
+}

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/linkTitleAutoLoader.js
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/linkTitleAutoLoader.js
@@ -1,12 +1,12 @@
 let titleHasFocus = false;
 
-window.addEventListener('load', _ => {
+window.addEventListener('load', () => {
     let titleField = document.getElementById('Title');
     let urlField = document.getElementById('LinkUrl');
 
-    titleField.addEventListener('focusin', _ => titleHasFocus = true);
-    titleField.addEventListener('focusout', _ => titleHasFocus = false);
-    urlField.addEventListener('focusout', _ => getTitle(_ => urlField.value, titleField));
+    titleField.addEventListener('focusin', () => titleHasFocus = true);
+    titleField.addEventListener('focusout', () => titleHasFocus = false);
+    urlField.addEventListener('focusout', () => getTitle(() => urlField.value, titleField));
 });
 
 function getTitle(urlValueGetter, titleField) {
@@ -20,7 +20,7 @@ function getTitle(urlValueGetter, titleField) {
 
         titleField.value = e.currentTarget.responseText;
     }
-    let onerror = _ => console.log("Failed to fetch title for current url");
+    let onerror = () => console.log("Failed to fetch title for current url");
 
     let requestUrl = new URL(`${window.location.origin}/api/autocompletion/LinkTitleAutocompletion`);
     requestUrl.searchParams.append('url', url);

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/linkTitleAutoLoader.js
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/wwwroot/js/linkTitleAutoLoader.js
@@ -1,0 +1,28 @@
+let titleHasFocus = false;
+
+window.addEventListener('load', _ => {
+    let titleField = document.getElementById('Title');
+    let urlField = document.getElementById('LinkUrl');
+
+    titleField.addEventListener('focusin', _ => titleHasFocus = true);
+    titleField.addEventListener('focusout', _ => titleHasFocus = false);
+    urlField.addEventListener('focusout', _ => getTitle(_ => urlField.value, titleField));
+});
+
+function getTitle(urlValueGetter, titleField) {
+    const url = urlValueGetter();
+    if (!url || titleField.value || titleHasFocus)
+        return;
+
+    let onload = e => {
+        if (titleField.value || titleHasFocus || e.currentTarget.status !== 200)
+            return;
+
+        titleField.value = e.currentTarget.responseText;
+    }
+    let onerror = _ => console.log("Failed to fetch title for current url");
+
+    let requestUrl = new URL(`${window.location.origin}/api/autocompletion/LinkTitleAutocompletion`);
+    requestUrl.searchParams.append('url', url);
+    performHttpRequest(requestUrl.toString(), 'GET', null, onload, onerror);
+}


### PR DESCRIPTION
Closes #164.

This uses a server-side proxy as CORS will not allow making such requests, as we don't even know the url beforehand to set the header properly.
I don't particularly like this solution though (hence the `TODO`), but as I cannot think of a better alternative right now, it will stay as it is.

The reason it's entirely in a controller method is that most logic here is extremely specific and I don't foresee this ever being used in another place.
If that ever happens I'll make a service out of it (unless a better solution presents itself in the meantime).