### PR TITLE
Fix quick create action forgetting query parameters

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/LinksController.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/LinksController.cs
@@ -85,10 +85,10 @@ namespace Rinkudesu.Gateways.Webui.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> QuickCreate(Uri? url)
+        public async Task<IActionResult> QuickCreate(Uri? url, Uri returnUrl)
         {
             if (url is null)
-                return this.ReturnBadRequest(Url.ActionLink(nameof(Index))!.ToUri(), _localizer["missingUrl"]);
+                return this.ReturnBadRequest(returnUrl, _localizer["missingUrl"]);
 
             var newLink = new LinkDto { Title = url.ToString(), LinkUrl = url, PrivacyOptions = LinkPrivacyOptionsDto.Private };
 
@@ -97,10 +97,10 @@ namespace Rinkudesu.Gateways.Webui.Controllers
             if (!isSuccess)
             {
                 if (Client.LastErrorReturned == "Link already exists")
-                    return this.ReturnBadRequest(Url.ActionLink(nameof(Index))!.ToUri(), _localizer["alreadyExists"]);
-                return this.ReturnBadRequest(Url.ActionLink(nameof(Index))!.ToUri(), _localizer["unableToCreate"]);
+                    return this.ReturnBadRequest(returnUrl, _localizer["alreadyExists"]);
+                return this.ReturnBadRequest(returnUrl, _localizer["unableToCreate"]);
             }
-            return Redirect(nameof(Index));
+            return LocalRedirect(returnUrl.ToString());
         }
 
         [HttpPost]

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/Links/_QuickCreatePartial.cshtml
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Views/Links/_QuickCreatePartial.cshtml
@@ -1,7 +1,9 @@
+@using Rinkudesu.Gateways.Webui.Utils
 @model Rinkudesu.Gateways.Webui.Models.LinkIndexViewModel
 @inject IViewLocalizer Localizer
 
 <form asp-action="QuickCreate" asp-antiforgery="true">
+    <input type="hidden" name="returnUrl" value="@Context.GetCurrentUrl()"/>
     <div class="mb-3 row">
         <div class="col-2">
             <label asp-for="LinkUrl" class="form-label"></label>


### PR DESCRIPTION
Fixed by sending `returnUrl` to the action and redirecting there at the end.

Note that this might cause newly added links to not be displayed due to filtering and sorting settings, but I feel like that's fine.

Closes #203.