### PR TITLE
Limit link title length when using quick create

### DIFF
--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Links/LinkDto.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Clients/Links/LinkDto.cs
@@ -15,6 +15,14 @@ namespace Rinkudesu.Gateways.Clients.Links
         public LinkPrivacyOptionsDto PrivacyOptions { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime LastUpdate { get; set; }
+
+        public static string LimitQuickAddTitle(Uri uri, int maxLength = 50)
+        {
+            var title = $"{uri.Scheme}://{uri.Authority}/";
+            if (title.Length > maxLength)
+                return title[..maxLength];
+            return title;
+        }
     }
 
     public enum LinkPrivacyOptionsDto

--- a/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/LinksController.cs
+++ b/Rinkudesu.Gateways.Webui/Rinkudesu.Gateways.Webui/Controllers/LinksController.cs
@@ -90,7 +90,7 @@ namespace Rinkudesu.Gateways.Webui.Controllers
             if (url is null)
                 return this.ReturnBadRequest(returnUrl, _localizer["missingUrl"]);
 
-            var newLink = new LinkDto { Title = url.ToString(), LinkUrl = url, PrivacyOptions = LinkPrivacyOptionsDto.Private };
+            var newLink = new LinkDto { Title = LinkDto.LimitQuickAddTitle(url), LinkUrl = url, PrivacyOptions = LinkPrivacyOptionsDto.Private };
 
             await SetJwt();
             var isSuccess = await Client.CreateLink(newLink) is not null;


### PR DESCRIPTION
The value of 50 has been chosen mostly at random, but it feels nice and anything longer would not be read by the user anyway.

Closes #205.